### PR TITLE
Ability to specify a commit hash to tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "my_tag"
 ```
+
+An optional commit sha can be specified to override the default
+
+```
+    steps:
+    - name: Tag commit
+      uses: tvdias/github-tagger@v0.0.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        tag: "my_tag"
+        commit-sha: abc123
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags the commit with a given text
 ## Getting Started
 To use, create a workflow (eg: `.github/workflows/label.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) and add a step like 'Tag commit' on the below sample. A token will be needed so the workflow can make calls to GitHub's rest API.
 
-```
+```yaml
 name: "My workflow"
 
 on: [push]
@@ -24,7 +24,7 @@ jobs:
 
 An optional commit sha can be specified to override the default
 
-```
+```yaml
     steps:
     - name: Tag commit
       uses: tvdias/github-tagger@v0.0.1

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ inputs:
   tag:
     description: 'Tag text'
     default: '0.1.0'
+  commit-sha:
+    description: optional commit sha to apply the tag to
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,7 +23,7 @@ function run() {
         try {
             const token = core.getInput('repo-token', { required: true });
             const tag = core.getInput('tag', { required: true });
-            const sha = github.context.sha;
+            const sha = core.getInput('commit-sha', { required: false }) || github.context.sha;
             const client = new github.GitHub(token);
             core.debug(`tagging #${sha} with tag ${tag}`);
             yield client.git.createRef({

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ async function run() {
   try {
     const token = core.getInput('repo-token', {required: true});
     const tag = core.getInput('tag', {required: true});
-    const sha = github.context.sha;
+    const sha = core.getInput('commit-sha', {required: false}) || github.context.sha;
 
     const client = new github.GitHub(token);
 


### PR DESCRIPTION
When a github action runs as part of a comment on a PR, it runs in the context of the HEAD sha.  I'm using a github workflow that allows pre-releasing a ruby gem by issuing a comment to a PR `prerelease gem`. 

In the workflow, we do some "magic" to get the current SHA of the PR (since the action is invoked with the SHA of the head) and then checkout that SHA. Like this:

```yaml
name: prerelease-gem

on: 
  issue_comment:
    types: [created]

jobs:
  prerelease:
    # Only run for comments starting with "prerelease " in a pull request.
    if: >
      startsWith(github.event.comment.body, 'prerelease gem')
      && startsWith(github.event.issue.pull_request.url, 'https://')

    runs-on: ubuntu-latest

    steps:
      # This step is needed because a comment on a PR is is in the scope of an issue
    - name: 'Load PR Details'
      id: load-pr
      run: |
        set -eu
        resp=$(curl -sSf \
          --url ${{ github.event.issue.pull_request.url }} \
          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
          --header 'content-type: application/json')
        sha=$(jq -r '.head.sha' <<< "$resp")
        echo "::set-output name=head_sha::$sha"
        comments_url=$(jq -r '.comments_url' <<< "$resp")
        echo "::set-output name=comments_url::$comments_url"

    - name: Checkout 
      uses: actions/checkout@1.0.0
      with:
        # By default (in a non-pull request build) you get HEAD of 'master'
        ref: ${{ steps.load-pr.outputs.head_sha }}
```

The output of `load-pr` is the actual commit sha (`head_sha` variable).  This is then used in checkout.

Because the tagging action just gets the "current" sha, it will always be tagging head.  By adding this small tweak, I can then do this in the workflow:

```yaml
    - name: Tag commit
      uses: dnorth98/github-tagger@v0.0.2
      with:
        repo-token: "${{ secrets.GITHUB_TOKEN }}"
        tag: "${{steps.get_version.outputs.version_tag}}"
        commit-sha: ${{ steps.load-pr.outputs.head_sha }}
```

and pass in the correct sha to tag.

**Testing**

I've tested this in my own release version and it works as you'd expect.  If accepted, you'd need to release a new version of the action since the `action.yml` has changed to expose the new input.