### PR TITLE
Mark repo-token as required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ author: 'Thiago Vaz Dias'
 inputs: 
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+    required: true
   tag:
     description: 'Tag text'
     default: '0.1.0'


### PR DESCRIPTION
By default, inputs are marked as 'optional'. But the action fails when there's no repo-token, so it is not optional.